### PR TITLE
Add an SLA report, DRY some markup, upgrade ESLint

### DIFF
--- a/nerdlets/groundskeeper-nerdlet/components/SLAReport.js
+++ b/nerdlets/groundskeeper-nerdlet/components/SLAReport.js
@@ -1,0 +1,180 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import BootstrapTable from 'react-bootstrap-table-next';
+import ToolkitProvider, { Search } from 'react-bootstrap-table2-toolkit';
+
+import { Spinner } from 'nr1';
+
+import { agentVersionInList } from '../helpers';
+
+export default class SLAReport extends React.Component {
+  static propTypes = {
+    slaReportKey: PropTypes.string.isRequired,
+    agentData: PropTypes.array.isRequired,
+    freshAgentVersions: PropTypes.object.isRequired,
+  };
+
+  state = {
+    tableContent: undefined,
+  };
+
+  componentDidMount() {
+    this.computeSLAReport();
+  }
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.slaReportKey !== prevProps.slaReportKey ||
+      this.props.agentData.length !== prevProps.agentData.length
+    ) {
+      this.computeSLAReport();
+    }
+  }
+
+  computeSLAReport = () => {
+    const { freshAgentVersions, slaReportKey, agentData } = this.props;
+
+    if (!slaReportKey || !agentData.length) {
+      this.setState({ tableContent: undefined });
+      return;
+    }
+
+    const slaReportData = {
+      '(undefined)': {
+        inSLA: 0,
+        outdated: 0,
+        multiple: 0,
+        unknown: 0,
+      },
+    };
+
+    agentData.forEach(info => {
+      const bucketTag = info.tags.find(t => t.key === slaReportKey) || {};
+      const bucketValues = bucketTag.values || ['(undefined)'];
+
+      const freshVersions = freshAgentVersions[info.language];
+      if (!freshVersions || freshVersions.length < 1) {
+        return;
+      }
+
+      const versions = (info.agentVersions || []).filter(
+        v => typeof v === 'string' && v.length > 0
+      );
+
+      bucketValues.forEach(bucket => {
+        if (!slaReportData[bucket]) {
+          slaReportData[bucket] = {
+            inSLA: 0,
+            outdated: 0,
+            multiple: 0,
+            unknown: 0,
+          };
+        }
+        if (versions.length < 1) {
+          slaReportData[bucket].unknown += 1;
+        } else if (info.agentVersions.length > 1) {
+          slaReportData[bucket].multiple += 1;
+        } else if (agentVersionInList(versions[0], freshVersions)) {
+          slaReportData[bucket].inSLA += 1;
+        } else {
+          slaReportData[bucket].outdated += 1;
+        }
+      });
+    });
+
+    const data = Object.keys(slaReportData)
+      .map(key => {
+        const val = slaReportData[key];
+        const total = val.inSLA + val.outdated + val.multiple + val.unknown;
+        if (total < 1) {
+          return undefined;
+        }
+        const pct = Math.floor((val.inSLA * 100) / total);
+        return {
+          key: key,
+          percentInSLA: pct,
+          inSLA: val.inSLA,
+          outdated: val.outdated,
+          multiple: val.multiple,
+          unknown: val.unknown,
+        };
+      })
+      .filter(d => d)
+      .sort((a, b) =>
+        a.percentInSLA > b.percentInSLA
+          ? -1
+          : a.percentInSLA === b.percentInSLA
+          ? 0
+          : 1
+      );
+
+    const tableContent = {
+      columns: [
+        {
+          dataField: 'key',
+          text: slaReportKey,
+          sort: true,
+        },
+        {
+          dataField: 'percentInSLA',
+          text: '% within SLA',
+          sort: true,
+        },
+        {
+          dataField: 'inSLA',
+          text: '# within SLA',
+          sort: true,
+        },
+        {
+          dataField: 'outdated',
+          text: '# outdated',
+          sort: true,
+        },
+        {
+          dataField: 'multiple',
+          text: '# w/ multiple versions',
+          sort: true,
+        },
+        {
+          dataField: 'unknown',
+          text: '# w/out reported version',
+          sort: true,
+        },
+      ],
+      data: data,
+    };
+
+    this.setState({ tableContent });
+  };
+
+  render() {
+    const { tableContent } = this.state;
+
+    if (!tableContent) {
+      return (
+        <div className="sla-report">
+          <Spinner />
+        </div>
+      );
+    }
+
+    const { SearchBar } = Search;
+
+    return (
+      <ToolkitProvider
+        wrapperClasses="table-responsive"
+        keyField="key"
+        data={tableContent.data}
+        columns={tableContent.columns}
+        search
+      >
+        {props => (
+          <>
+            <SearchBar {...props.searchProps} />
+            <BootstrapTable {...props.baseProps} />
+          </>
+        )}
+      </ToolkitProvider>
+    );
+  }
+}

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -18,6 +18,7 @@ import {
 } from 'nr1';
 
 import AgentVersion from './components/AgentVersion';
+import SLAReport from './components/SLAReport';
 
 import {
   linkedAppId,
@@ -55,6 +56,8 @@ export default class Groundskeeper extends React.Component {
 
     filterKey: undefined,
     filterValue: undefined,
+
+    slaReportKey: undefined,
   };
 
   componentDidMount() {
@@ -77,6 +80,10 @@ export default class Groundskeeper extends React.Component {
     this.setState({ filterValue: val || undefined }, () => {
       this.recomputePresentation(this.state.agentData);
     });
+  };
+
+  setSLAReportKey = val => {
+    this.setState({ slaReportKey: val || undefined });
   };
 
   updateAgentSLO = slo => {
@@ -632,6 +639,7 @@ export default class Groundskeeper extends React.Component {
       updateAgentSLO,
       setFilterKey,
       setFilterValue,
+      setSLAReportKey,
       setTableState,
       getTableStateCount,
       state: {
@@ -647,6 +655,7 @@ export default class Groundskeeper extends React.Component {
         filterKey,
         filterValue,
         tableState,
+        slaReportKey,
       },
     } = this;
 
@@ -775,6 +784,27 @@ export default class Groundskeeper extends React.Component {
                       </DropdownItem>
                     </Dropdown>
                   </StackItem>
+                  <StackItem className="toolbar-item has-separator">
+                    <Dropdown
+                      label="Show SLA Report by"
+                      title={slaReportKey === undefined ? '--' : slaReportKey}
+                    >
+                      <DropdownItem onClick={() => setSLAReportKey('')}>
+                        --
+                      </DropdownItem>
+                      {Object.keys(tags)
+                        .sort()
+                        .map(key => (
+                          <DropdownItem
+                            key={`filter-tag-${key}`}
+                            value={key}
+                            onClick={() => setSLAReportKey(key)}
+                          >
+                            {key}
+                          </DropdownItem>
+                        ))}
+                    </Dropdown>
+                  </StackItem>
                 </Stack>
               </StackItem>
               <StackItem className="toolbar-section2">
@@ -825,7 +855,15 @@ export default class Groundskeeper extends React.Component {
             </p>
             <Grid spacingType={[Grid.SPACING_TYPE.LARGE]}>
               <GridItem columnSpan={9} className="primary-table-grid-item">
-                {this.renderTableState()}
+                {slaReportKey ? (
+                  <SLAReport
+                    slaReportKey={slaReportKey}
+                    agentData={agentData}
+                    freshAgentVersions={freshAgentVersions}
+                  />
+                ) : (
+                  this.renderTableState()
+                )}
               </GridItem>
               <GridItem columnSpan={3} className="secondary-table-grid-item">
                 <AgentVersion

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -671,6 +671,22 @@ export default class Groundskeeper extends React.Component {
     const upToDateLabel = agentSloOptions[agentSLO].label;
     const scanner = scanIsRunning ? <Spinner inline /> : undefined;
 
+    const tableBannerText = slaReportKey
+      ? `SLA Report by ${slaReportKey}`
+      : tableState === 'outOfDate'
+      ? `${presentationData.outdatedTable.data.length} apps are running
+              outdated agents`
+      : tableState === 'multipleVersions'
+      ? `${presentationData.multiversionTable.data.length} apps are running
+              multiple agent versions`
+      : tableState === 'upToDate'
+      ? `${presentationData.currentTable.data.length} apps are up to date
+              with ${upToDateLabel}`
+      : tableState === 'noVersionReported'
+      ? `${presentationData.noVersionsTable.data.length} apps are not
+              reporting agent version data (they may be inactive)`
+      : undefined;
+
     return (
       <div className="gk-content">
         {loadError ? (
@@ -821,38 +837,11 @@ export default class Groundskeeper extends React.Component {
                 </Stack>
               </StackItem>
             </Stack>
-            <p
-              className={`${
-                tableState !== 'outOfDate' ? 'hidden' : ''
-              } table-state-count`}
-            >
-              {presentationData.outdatedTable.data.length} apps are running
-              outdated agents
-            </p>
-            <p
-              className={`${
-                tableState !== 'multipleVersions' ? 'hidden' : ''
-              } table-state-count`}
-            >
-              {presentationData.multiversionTable.data.length} apps are running
-              multiple agent versions
-            </p>
-            <p
-              className={`${
-                tableState !== 'upToDate' ? 'hidden' : ''
-              } table-state-count`}
-            >
-              {presentationData.currentTable.data.length} apps are up to date
-              with {upToDateLabel}
-            </p>
-            <p
-              className={`${
-                tableState !== 'noVersionReported' ? 'hidden' : ''
-              } table-state-count`}
-            >
-              {presentationData.noVersionsTable.data.length} apps are not
-              reporting agent version data (they may be inactive)
-            </p>
+            {tableBannerText ? (
+              <p className={`table-state-count`}>{tableBannerText}</p>
+            ) : (
+              undefined
+            )}
             <Grid spacingType={[Grid.SPACING_TYPE.LARGE]}>
               <GridItem columnSpan={9} className="primary-table-grid-item">
                 {slaReportKey ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1421,6 +1421,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1503,9 +1509,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -1527,9 +1533,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -1561,12 +1567,20 @@
       }
     },
     "ansi-escapes": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
-      "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.5.2"
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
       }
     },
     "ansi-regex": {
@@ -2575,9 +2589,9 @@
       }
     },
     "eslint": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
-      "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2595,7 +2609,7 @@
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2608,7 +2622,7 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^6.1.2",
@@ -2638,6 +2652,15 @@
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true
             }
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
           }
         },
         "ignore": {
@@ -2756,13 +2779,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.1.0",
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -2773,9 +2796,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -3061,9 +3084,9 @@
       }
     },
     "figures": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -4025,24 +4048,85 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
+        "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
-        "strip-ansi": "^5.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "invariant": {
@@ -6542,9 +6626,9 @@
       "dev": true
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
@@ -6557,9 +6641,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -7440,9 +7524,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
     "tunnel-agent": {
@@ -7470,9 +7554,9 @@
       }
     },
     "type-fest": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/preset-react": "^7.7.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
-    "eslint": "^6.4.0",
+    "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.14.3",


### PR DESCRIPTION
This PR adds a new SLA Report feature. When viewing the report, picking a SLA tag name generates an SLA report for the apps classified in each value of the chosen tag. For example, choosing SLA Report on `language` generates an SLA report indicating what % of apps written in each language (python, java, go, etc.) have agents new enough to fall within your chosen SLO.

Also DRY up presentation of the "X apps are ..." banner and upgrade ESLint.