### PR TITLE
fix(perf): swap moment.js for date-fns

### DIFF
--- a/nerdlets/groundskeeper-nerdlet/components/AgentVersion.js
+++ b/nerdlets/groundskeeper-nerdlet/components/AgentVersion.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import BootstrapTable from 'react-bootstrap-table-next';
+import { format } from 'date-fns';
 
 export default class AgentVersion extends React.PureComponent {
   static propTypes = {
@@ -34,9 +35,11 @@ export default class AgentVersion extends React.PureComponent {
         id: index,
         language: lng,
         version: freshAgentVersions[lng][0],
-        releasedOn: agentVersions[lng]
-          .find(v => v.version === freshAgentVersions[lng][0])
-          .date.format('MMM Do YYYY'),
+        releasedOn: format(
+          agentVersions[lng].find(v => v.version === freshAgentVersions[lng][0])
+            .date,
+          'MMM do yyyy'
+        ),
       }));
 
     return (

--- a/nerdlets/groundskeeper-nerdlet/helpers.js
+++ b/nerdlets/groundskeeper-nerdlet/helpers.js
@@ -1,5 +1,5 @@
 import { Link, navigation } from 'nr1';
-import moment from 'moment';
+import { subWeeks, subMonths, isSameDay, isBefore } from 'date-fns';
 
 function linkedAppId(accountId, appId) {
   let entityGuid = btoa(`${accountId}|APM|APPLICATION|${appId}`);
@@ -101,36 +101,40 @@ const agentSloOptions = [
   {
     label: 'agents < 2 weeks old',
     filterFunc: versions => {
-      const fresh = moment().subtract(14, 'days');
+      const fresh = subWeeks(new Date(), 2);
       return versions.filter(
-        (ver, index) => index === 0 || fresh.isSameOrBefore(ver.date)
+        (ver, index) =>
+          index === 0 || isSameDay(fresh, ver.date) || isBefore(fresh, ver.date)
       );
     },
   },
   {
     label: 'agents < 1 month old',
     filterFunc: versions => {
-      const fresh = moment().subtract(1, 'month');
+      const fresh = subMonths(new Date(), 1);
       return versions.filter(
-        (ver, index) => index === 0 || fresh.isSameOrBefore(ver.date)
+        (ver, index) =>
+          index === 0 || isSameDay(fresh, ver.date) || isBefore(fresh, ver.date)
       );
     },
   },
   {
     label: 'agents < 6 months old',
     filterFunc: versions => {
-      const fresh = moment().subtract(6, 'months');
+      const fresh = subMonths(new Date(), 6);
       return versions.filter(
-        (ver, index) => index === 0 || fresh.isSameOrBefore(ver.date)
+        (ver, index) =>
+          index === 0 || isSameDay(fresh, ver.date) || isBefore(fresh, ver.date)
       );
     },
   },
   {
     label: 'agents < 1 year old (Support cutoff)',
     filterFunc: versions => {
-      const fresh = moment().subtract(12, 'months');
+      const fresh = subMonths(new Date(), 12);
       return versions.filter(
-        (ver, index) => index === 0 || fresh.isSameOrBefore(ver.date)
+        (ver, index) =>
+          index === 0 || isSameDay(fresh, ver.date) || isBefore(fresh, ver.date)
       );
     },
   },

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -322,7 +322,6 @@ export default class Groundskeeper extends React.Component {
       if (al && al.map && al.length > 0) {
         agentVersions[language] = al
           .map(ver => {
-            const blessed = parseISO(ver.date);
             return {
               version: cleanAgentVersion(ver.version),
               date: parseISO(ver.date),

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -2,7 +2,11 @@ import './styles.scss';
 import { startCase } from 'lodash';
 import BootstrapTable from 'react-bootstrap-table-next';
 import ToolkitProvider, { Search } from 'react-bootstrap-table2-toolkit';
-import moment from 'moment';
+import {
+  parseISO,
+  differenceInMilliseconds,
+  differenceInWeeks,
+} from 'date-fns';
 
 import React from 'react';
 
@@ -318,9 +322,10 @@ export default class Groundskeeper extends React.Component {
       if (al && al.map && al.length > 0) {
         agentVersions[language] = al
           .map(ver => {
+            const blessed = parseISO(ver.date);
             return {
               version: cleanAgentVersion(ver.version),
-              date: moment(ver.date),
+              date: parseISO(ver.date),
             };
           })
           .sort((a, b) => {
@@ -528,7 +533,7 @@ export default class Groundskeeper extends React.Component {
         };
       }),
     };
-    const now = moment();
+    const now = new Date();
     analysis.outdatedTable = {
       columns: [
         {
@@ -572,14 +577,14 @@ export default class Groundskeeper extends React.Component {
           if (!ageA && !ageB) return 0;
           if (!ageA) return 1;
           if (!ageB) return -1;
-          const d = ageA.diff(ageB);
+          const d = differenceInMilliseconds(ageA, ageB);
           if (d < 0) return -1;
           if (d > 0) return 1;
           return 0;
         })
         .map((info, index) => {
           const age = agentAge(info, agentVersions);
-          const ageInWeeks = age ? now.diff(age, 'weeks') : -1;
+          const ageInWeeks = age ? differenceInWeeks(now, age) : -1;
           return {
             key: index,
             agentAge: [age, ageInWeeks],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "groundskeeper",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2354,6 +2354,11 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.0.tgz",
+      "integrity": "sha512-8P1cDi8ebZyDxUyUprBXwidoEtiQAawYPGvpfb+Dg0G6JrQ+VozwOmm91xYC0vAv1+0VmLehEPb+isg4BGUFfA=="
     },
     "debug": {
       "version": "4.1.1",
@@ -5656,11 +5661,6 @@
           "dev": true
         }
       }
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint-fix": "eslint nerdlets/ --fix"
   },
   "dependencies": {
-    "moment": "^2.24.0",
+    "date-fns": "^2.11.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-bootstrap-table-next": "^3.3.3",


### PR DESCRIPTION
As this nerdpack is a NR1 catalog project, and will be viewed as a model for how others should produce nerdpacks we want to encourage the use of a [smaller](https://github.com/you-dont-need/You-Dont-Need-Momentjs) and [more efficient](https://inventi.studio/en/blog/why-you-shouldnt-use-moment-js) date library. Of the many solid alternatives, we've gone with [date-fns](https://date-fns.org/v2.11.0/docs/parse) here.

- Adds date-fns as a project dependancy
- Swaps out all moment funcitons for date-fns equivalents
- Removes moment.js as a project dependancy

This PR, when merged, will close #21

---

note: that second article has a sensational/inaccurate title, but the idea is there.