### PR TITLE
fix: Remove deprecated nr1 Dropdown component implementations

### DIFF
--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -89,8 +89,6 @@ export default class Groundskeeper extends React.Component {
   };
 
   updateAgentSLO = (event, value) => {
-console.log("value", value);
-console.log("agentSloOptions[this.state.agentSLO].label", agentSloOptions[this.state.agentSLO].label)
     if (value === this.state.agentSLO) {
       return;
     }

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -83,8 +83,8 @@ export default class Groundskeeper extends React.Component {
     });
   };
 
-  setSLAReportKey = val => {
-    this.setState({ slaReportKey: val || undefined });
+  setSLAReportKey = (event, value) => {
+    this.setState({ slaReportKey: value || undefined });
   };
 
   updateAgentSLO = (event, value) => {
@@ -780,25 +780,25 @@ export default class Groundskeeper extends React.Component {
                     </Select>
                   </StackItem>
                   <StackItem className="toolbar-item has-separator">
-                    <Dropdown
+                    <Select
                       label="Show SLA Report by"
-                      title={slaReportKey === undefined ? '--' : slaReportKey}
+                      value={slaReportKey}
+                      onChange={setSLAReportKey}
                     >
-                      <DropdownItem onClick={() => setSLAReportKey('')}>
+                      <SelectItem value=''>
                         --
-                      </DropdownItem>
+                      </SelectItem>
                       {Object.keys(tags)
                         .sort()
                         .map(key => (
-                          <DropdownItem
+                          <SelectItem
                             key={`filter-tag-${key}`}
                             value={key}
-                            onClick={() => setSLAReportKey(key)}
                           >
                             {key}
-                          </DropdownItem>
+                          </SelectItem>
                         ))}
-                    </Dropdown>
+                    </Select>
                   </StackItem>
                 </Stack>
               </StackItem>

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { startCase } from 'lodash';
 import BootstrapTable from 'react-bootstrap-table-next';
 import ToolkitProvider, { Search } from 'react-bootstrap-table2-toolkit';
 import {
@@ -12,10 +11,8 @@ import {
   Spinner,
   Stack,
   StackItem,
-  Dropdown,
   Select,
   SelectItem,
-  DropdownItem,
   Grid,
   GridItem
 } from 'nr1';

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -715,8 +715,7 @@ export default class Groundskeeper extends React.Component {
                   <StackItem className="toolbar-item has-separator">
                     <Select
                       label="My Upgrade SLO is"
-                      // TODO(rtyree): What we pass to this 'value' prop isn't updating the Select value. Must fix
-                      value={agentSloOptions[this.state.agentSLO].label}
+                      value={this.state.agentSLO}
                       onChange={updateAgentSLO}
                     >
                       {agentSloOptions.map((slo, index) => (

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -103,9 +103,9 @@ export default class Groundskeeper extends React.Component {
     });
   };
 
-  setTableState(tableState) {
+  setTableState = (event, value) => {
     this.setState({
-      tableState: tableState
+      tableState: value,
     });
   }
 
@@ -657,7 +657,7 @@ export default class Groundskeeper extends React.Component {
         filterKey,
         filterValue,
         tableState,
-        slaReportKey
+        slaReportKey,
       }
     } = this;
 
@@ -774,32 +774,24 @@ export default class Groundskeeper extends React.Component {
                     </StackItem>
                   )}
                   <StackItem className="toolbar-item">
-                    <Dropdown
+                    <Select
                       label="Filter by state"
-                      title={`${startCase(tableState)} (${getTableStateCount(
-                        tableState
-                      )})`}
+                      value={tableState}
+                      onChange={setTableState}
                     >
-                      <DropdownItem onClick={() => setTableState('upToDate')}>
-                        Up to date ({presentationData.currentTable.data.length})
-                      </DropdownItem>
-                      <DropdownItem
-                        onClick={() => setTableState('multipleVersions')}
-                      >
-                        Multiple versions (
-                        {presentationData.multiversionTable.data.length})
-                      </DropdownItem>
-                      <DropdownItem onClick={() => setTableState('outOfDate')}>
-                        Out of date (
-                        {presentationData.outdatedTable.data.length})
-                      </DropdownItem>
-                      <DropdownItem
-                        onClick={() => setTableState('noVersionReported')}
-                      >
-                        No version reported (
-                        {presentationData.noVersionsTable.data.length})
-                      </DropdownItem>
-                    </Dropdown>
+                      <SelectItem value='upToDate'>
+                        {`Up to date (${presentationData.currentTable.data.length})`}
+                      </SelectItem>
+                      <SelectItem value='multipleVersions'>
+                        {`Multiple versions (${presentationData.multiversionTable.data.length})`}
+                      </SelectItem>
+                      <SelectItem  value='outOfDate'>
+                         {`Out of date (${presentationData.outdatedTable.data.length})`}
+                      </SelectItem>
+                      <SelectItem value='noVersionReported'>
+                        {`No version reported (${presentationData.noVersionsTable.data.length})`}
+                      </SelectItem>
+                    </Select>
                   </StackItem>
                   <StackItem className="toolbar-item has-separator">
                     <Dropdown

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -65,7 +65,7 @@ export default class Groundskeeper extends React.Component {
   loaders = undefined;
   initialEntityDataSet = false;
 
-  setFilterKey =  (event, value)  => {
+  setFilterKey = (event, value) => {
     this.setState(
       { filterKey: value || undefined, filterValue: undefined },
       () => {
@@ -90,7 +90,7 @@ export default class Groundskeeper extends React.Component {
     }
 
     const newState =
-    value >= 0 && value < agentSloOptions.length
+      value >= 0 && value < agentSloOptions.length
         ? { agentSLO: value }
         : { agentSLO: defaultAgentSloOption };
 
@@ -101,9 +101,9 @@ export default class Groundskeeper extends React.Component {
 
   setTableState = (event, value) => {
     this.setState({
-      tableState: value,
+      tableState: value
     });
-  }
+  };
 
   renderTableState() {
     const { presentationData, tableState } = this.state;
@@ -640,7 +640,7 @@ export default class Groundskeeper extends React.Component {
         filterKey,
         filterValue,
         tableState,
-        slaReportKey,
+        slaReportKey
       }
     } = this;
 
@@ -702,10 +702,7 @@ export default class Groundskeeper extends React.Component {
                       onChange={updateAgentSLO}
                     >
                       {agentSloOptions.map((slo, index) => (
-                        <SelectItem
-                          value={index}
-                          key={`slo-opt-${index}`}
-                        >
+                        <SelectItem value={index} key={`slo-opt-${index}`}>
                           {slo.label}
                         </SelectItem>
                       ))}
@@ -721,18 +718,11 @@ export default class Groundskeeper extends React.Component {
                       value={filterKey}
                       onChange={setFilterKey}
                     >
-                      <SelectItem 
-                        value={''}
-                      >
-                        --
-                      </SelectItem>
+                      <SelectItem value="">--</SelectItem>
                       {Object.keys(tags)
                         .sort()
                         .map(key => (
-                          <SelectItem
-                            key={`filter-tag-${key}`}
-                            value={key}
-                          >
+                          <SelectItem key={`filter-tag-${key}`} value={key}>
                             {key}
                           </SelectItem>
                         ))}
@@ -746,10 +736,7 @@ export default class Groundskeeper extends React.Component {
                         onChange={setFilterValue}
                       >
                         {tags[filterKey].sort().map(val => (
-                          <SelectItem
-                            key={`filter-val-${val}`}
-                            value={val}
-                          >
+                          <SelectItem key={`filter-val-${val}`} value={val}>
                             {val}
                           </SelectItem>
                         ))}
@@ -762,16 +749,16 @@ export default class Groundskeeper extends React.Component {
                       value={tableState}
                       onChange={setTableState}
                     >
-                      <SelectItem value='upToDate'>
+                      <SelectItem value="upToDate">
                         {`Up to date (${presentationData.currentTable.data.length})`}
                       </SelectItem>
-                      <SelectItem value='multipleVersions'>
+                      <SelectItem value="multipleVersions">
                         {`Multiple versions (${presentationData.multiversionTable.data.length})`}
                       </SelectItem>
-                      <SelectItem  value='outOfDate'>
-                         {`Out of date (${presentationData.outdatedTable.data.length})`}
+                      <SelectItem value="outOfDate">
+                        {`Out of date (${presentationData.outdatedTable.data.length})`}
                       </SelectItem>
-                      <SelectItem value='noVersionReported'>
+                      <SelectItem value="noVersionReported">
                         {`No version reported (${presentationData.noVersionsTable.data.length})`}
                       </SelectItem>
                     </Select>
@@ -782,16 +769,11 @@ export default class Groundskeeper extends React.Component {
                       value={slaReportKey}
                       onChange={setSLAReportKey}
                     >
-                      <SelectItem value=''>
-                        --
-                      </SelectItem>
+                      <SelectItem value="">--</SelectItem>
                       {Object.keys(tags)
                         .sort()
                         .map(key => (
-                          <SelectItem
-                            key={`filter-tag-${key}`}
-                            value={key}
-                          >
+                          <SelectItem key={`filter-tag-${key}`} value={key}>
                             {key}
                           </SelectItem>
                         ))}

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -38,7 +38,6 @@ export default class Groundskeeper extends React.Component {
     super(props);
 
     this.setTableState = this.setTableState.bind(this);
-    this.getTableStateCount = this.getTableStateCount.bind(this);
   }
 
   state = {
@@ -107,18 +106,6 @@ export default class Groundskeeper extends React.Component {
     this.setState({
       tableState: value,
     });
-  }
-
-  getTableStateCount(tableState) {
-    if (tableState === 'upToDate') {
-      return this.state.presentationData.currentTable.data.length;
-    } else if (tableState === 'multipleVersions') {
-      return this.state.presentationData.multiversionTable.data.length;
-    } else if (tableState === 'outOfDate') {
-      return this.state.presentationData.outdatedTable.data.length;
-    } else if (tableState === 'noVersionReported') {
-      return this.state.presentationData.noVersionsTable.data.length;
-    }
   }
 
   renderTableState() {
@@ -643,7 +630,6 @@ export default class Groundskeeper extends React.Component {
       setFilterValue,
       setSLAReportKey,
       setTableState,
-      getTableStateCount,
       state: {
         agentData,
         agentSLO,

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -13,6 +13,8 @@ import {
   Stack,
   StackItem,
   Dropdown,
+  Select,
+  SelectItem,
   DropdownItem,
   Grid,
   GridItem
@@ -711,20 +713,20 @@ export default class Groundskeeper extends React.Component {
                   verticalType={Stack.VERTICAL_TYPE.FILL}
                 >
                   <StackItem className="toolbar-item has-separator">
-                    <Dropdown
+                    <Select
                       label="My Upgrade SLO is"
                       title={agentSloOptions[this.state.agentSLO].label}
                     >
                       {agentSloOptions.map((slo, index) => (
-                        <DropdownItem
+                        <SelectItem
                           value={slo.label}
                           key={`slo-opt-${index}`}
                           onClick={() => updateAgentSLO(index)}
                         >
                           {slo.label}
-                        </DropdownItem>
+                        </SelectItem>
                       ))}
-                    </Dropdown>
+                    </Select>
                   </StackItem>
                   <StackItem
                     className={`toolbar-item ${

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -69,9 +69,9 @@ export default class Groundskeeper extends React.Component {
   loaders = undefined;
   initialEntityDataSet = false;
 
-  setFilterKey = key => {
+  setFilterKey =  (event, value)  => {
     this.setState(
-      { filterKey: key || undefined, filterValue: undefined },
+      { filterKey: value || undefined, filterValue: undefined },
       () => {
         this.recomputePresentation(this.state.agentData);
       }
@@ -715,7 +715,7 @@ export default class Groundskeeper extends React.Component {
                   <StackItem className="toolbar-item has-separator">
                     <Select
                       label="My Upgrade SLO is"
-                      value={this.state.agentSLO}
+                      value={agentSLO}
                       onChange={updateAgentSLO}
                     >
                       {agentSloOptions.map((slo, index) => (
@@ -733,25 +733,27 @@ export default class Groundskeeper extends React.Component {
                       filterKey ? '' : 'has-separator'
                     }`}
                   >
-                    <Dropdown
+                    <Select
                       label="Filter applications by tag"
-                      title={filterKey === undefined ? '--' : filterKey}
+                      value={filterKey}
+                      onChange={setFilterKey}
                     >
-                      <DropdownItem onClick={() => setFilterKey('')}>
+                      <SelectItem 
+                        value={''}
+                      >
                         --
-                      </DropdownItem>
+                      </SelectItem>
                       {Object.keys(tags)
                         .sort()
                         .map(key => (
-                          <DropdownItem
+                          <SelectItem
                             key={`filter-tag-${key}`}
                             value={key}
-                            onClick={() => setFilterKey(key)}
                           >
                             {key}
-                          </DropdownItem>
+                          </SelectItem>
                         ))}
-                    </Dropdown>
+                    </Select>
                   </StackItem>
                   {filterKey && (
                     <StackItem className="toolbar-item has-separator">

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -88,14 +88,16 @@ export default class Groundskeeper extends React.Component {
     this.setState({ slaReportKey: val || undefined });
   };
 
-  updateAgentSLO = slo => {
-    if (slo === this.state.agentSLO) {
+  updateAgentSLO = (event, value) => {
+console.log("value", value);
+console.log("agentSloOptions[this.state.agentSLO].label", agentSloOptions[this.state.agentSLO].label)
+    if (value === this.state.agentSLO) {
       return;
     }
 
     const newState =
-      slo >= 0 && slo < agentSloOptions.length
-        ? { agentSLO: slo }
+    value >= 0 && value < agentSloOptions.length
+        ? { agentSLO: value }
         : { agentSLO: defaultAgentSloOption };
 
     this.setState(newState, () => {
@@ -715,13 +717,14 @@ export default class Groundskeeper extends React.Component {
                   <StackItem className="toolbar-item has-separator">
                     <Select
                       label="My Upgrade SLO is"
-                      title={agentSloOptions[this.state.agentSLO].label}
+                      // TODO(rtyree): What we pass to this 'value' prop isn't updating the Select value. Must fix
+                      value={agentSloOptions[this.state.agentSLO].label}
+                      onChange={updateAgentSLO}
                     >
                       {agentSloOptions.map((slo, index) => (
                         <SelectItem
-                          value={slo.label}
+                          value={index}
                           key={`slo-opt-${index}`}
-                          onClick={() => updateAgentSLO(index)}
                         >
                           {slo.label}
                         </SelectItem>

--- a/nerdlets/groundskeeper-nerdlet/index.js
+++ b/nerdlets/groundskeeper-nerdlet/index.js
@@ -78,8 +78,8 @@ export default class Groundskeeper extends React.Component {
     );
   };
 
-  setFilterValue = val => {
-    this.setState({ filterValue: val || undefined }, () => {
+  setFilterValue = (event, value) => {
+    this.setState({ filterValue: value || undefined }, () => {
       this.recomputePresentation(this.state.agentData);
     });
   };
@@ -757,20 +757,20 @@ export default class Groundskeeper extends React.Component {
                   </StackItem>
                   {filterKey && (
                     <StackItem className="toolbar-item has-separator">
-                      <Dropdown
+                      <Select
                         label="to value"
-                        title={filterValue !== undefined ? filterValue : '--'}
+                        value={filterValue}
+                        onChange={setFilterValue}
                       >
                         {tags[filterKey].sort().map(val => (
-                          <DropdownItem
+                          <SelectItem
                             key={`filter-val-${val}`}
                             value={val}
-                            onClick={() => setFilterValue(val)}
                           >
                             {val}
-                          </DropdownItem>
+                          </SelectItem>
                         ))}
-                      </Dropdown>
+                      </Select>
                     </StackItem>
                   )}
                   <StackItem className="toolbar-item">

--- a/nr1.json
+++ b/nr1.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "NERDPACK",
-  "id": "230df80a-007d-45ea-80aa-3b92d0b7ad94",
+  "id": "4a13b4e8-3129-467b-a099-ba5f503fe47f",
   "displayName": "Groundskeeper",
   "description": "Generate a live view of all the APM agents across your Services."
 }

--- a/nr1.json
+++ b/nr1.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "NERDPACK",
-  "id": "4a13b4e8-3129-467b-a099-ba5f503fe47f",
+  "id": "230df80a-007d-45ea-80aa-3b92d0b7ad94",
   "displayName": "Groundskeeper",
   "description": "Generate a live view of all the APM agents across your Services."
 }


### PR DESCRIPTION
Addresses: https://github.com/newrelic/nr1-groundskeeper/issues/56

This codebase has 5 `Dropdown` components ([docs](https://developer.newrelic.com/components/select)) using the soon to be deprecated `label` prop. 

Each `Dropdown` seems to require refactoring into a `Select` component ([docs](https://developer.newrelic.com/components/select)). 

This PR moves all event handling logic move from `onClick`, currently on the `DropdownItem`, to `onChange` on the parent `Select`.